### PR TITLE
Add default Rake task

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,6 @@ bundler_args: --local
 before_script:
   - cp config/config.yml.example config/config.yml
 
-script: rake tests:all
-
 notifications:
   email:
     recipients:

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+task default: 'tests:all'
+
 task :environment do
   require 'rubygems'
   require 'bundler/setup'


### PR DESCRIPTION
So now I can just run `rake` to run tests (as in most gems, apps, etc.). That's also what Travis expects, so we can make `.travis.yml` simpler.
