### PR TITLE
Make sunlight_announcements functionality more generic

### DIFF
--- a/app/controllers/account.rb
+++ b/app/controllers/account.rb
@@ -43,7 +43,7 @@ put '/account/settings' do
 
   # special case for checkboxes, sigh
   if params[:user]
-    ['announcements', 'sunlight_announcements'].each do |field|
+    ['announcements', 'organization_announcements'].each do |field|
       current_user.send "#{field}=", (["false", false, nil].include?(params[:user][field]) ? false : true)
     end
   end
@@ -130,7 +130,7 @@ put '/account/welcome' do
   requires_login
 
   if params[:user]
-    ['announcements', 'sunlight_announcements'].each do |field|
+    ['announcements', 'organization_announcements'].each do |field|
       current_user.send "#{field}=", (["false", false, nil].include?(params[:user][field]) ? false : true)
     end
   end

--- a/app/controllers/login.rb
+++ b/app/controllers/login.rb
@@ -41,7 +41,7 @@ post '/account/new' do
   end
 
   @new_user = User.new
-  ['email', 'password', 'password_confirmation', 'announcements', 'sunlight_announcements'].each do |field|
+  ['email', 'password', 'password_confirmation', 'announcements', 'organization_announcements'].each do |field|
     @new_user.send "#{field}=", params[:user][field]
   end
 

--- a/app/controllers/remote.rb
+++ b/app/controllers/remote.rb
@@ -16,7 +16,7 @@
 #   with the provided 'notifications' field
 #   with the provided email address
 #   confirmed=true
-#   announcements and sunlight_announcements as false
+#   announcements and organization_announcements as false
 #   random password (unsynced with other service)
 #
 # If the user account is invalid somehow, 400.
@@ -66,7 +66,7 @@ post "/remote/service/sync" do
       notifications: data['notifications'],
       
       announcements: false,
-      sunlight_announcements: false
+      organization_announcements: false
     )
 
     user.confirmed = true
@@ -205,7 +205,7 @@ end
 #   source: "remote"
 #   confirmed: false
 #   announcements: false
-#   sunlight_announcements: false
+#   organization_announcements: false
 #   notifications: none
 #   phone: [phone number]
 #   phone_confirmed: false
@@ -233,7 +233,7 @@ post "/remote/subscribe/sms" do
     user = User.new(
       phone: params[:phone],
       announcements: false,
-      sunlight_announcements: false,
+      organization_announcements: false,
       notifications: "none"
     )
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,7 +22,7 @@ class User
 
   # announcement list booleans
   field :announcements, type: Boolean, default: false
-  field :sunlight_announcements, type: Boolean, default: false
+  field :sunlight_announcements, as: :organization_announcements, type: Boolean, default: false
 
   # used for sharing things
   field :username
@@ -96,7 +96,7 @@ class User
   field :signup_process, default: nil # can be "quick"
 
   attr_accessible :email, :username, :display_name, :phone,
-    :notifications, :announcements, :sunlight_announcements,
+    :notifications, :announcements, :organization_announcements,
     :bio, :image, :url, :contact_email
 
   attr_accessor :password, :password_confirmation
@@ -248,13 +248,13 @@ class User
     old_info = {
       notifications: self.notifications,
       announcements: self.announcements,
-      sunlight_announcements: self.sunlight_announcements,
+      organization_announcements: self.organization_announcements,
       service: self.service # context
     }
 
     self.notifications = "none"
     self.announcements = false
-    self.sunlight_announcements = false
+    self.organization_announcements = false
     self.save!
 
     # unsubscribe individual interests

--- a/app/views/account/login.erb
+++ b/app/views/account/login.erb
@@ -53,9 +53,9 @@
         <span>Get updates about new Scout features</span>
       </label>
 
-      <label for="sunlight_announcements">
-        <%= check_box_tag "user[sunlight_announcements]", checked: @new_user.sunlight_announcements?, uncheck_value: 'false', id: "sunlight_announcements" %>
-        <span>Get updates about the Sunlight Foundation</span>
+      <label for="organization_announcements">
+        <%= check_box_tag "user[organization_announcements]", checked: @new_user.organization_announcements?, uncheck_value: 'false', id: "organization_announcements" %>
+        <span>Get updates about the <%= Environment.config['organization']['name'] %></span>
       </label>
 
       <button type="submit" class="text login"><span>Sign Up</span></button>

--- a/app/views/account/mail/confirm_account.erb
+++ b/app/views/account/mail/confirm_account.erb
@@ -9,7 +9,7 @@
 <hr/>
 
 <p>
-This email is sent from <a href="<%= Environment.config['hostname'] %>">Scout</a>, a service of the <a href="http://sunlightfoundation.com">Sunlight Foundation</a>.
+This email is sent from <a href="<%= Environment.config['hostname'] %>">Scout</a>, a service of the <a href="<%= Environment.config['organization']['url'] %>"><%= Environment.config['organization']['name'] %></a>.
 </p>
 
 <p>

--- a/app/views/account/mail/new_password.erb
+++ b/app/views/account/mail/new_password.erb
@@ -15,7 +15,7 @@ Your new password: <%= new_password %>
 <hr/>
 
 <p>
-This email is sent from <a href="<%= Environment.config['hostname'] %>">Scout</a>, a service of the <a href="http://sunlightfoundation.com">Sunlight Foundation</a>.
+This email is sent from <a href="<%= Environment.config['hostname'] %>">Scout</a>, a service of the <a href="<%= Environment.config['organization']['url'] %>"><%= Environment.config['organization']['name'] %></a>.
 </p>
 
 <p>

--- a/app/views/account/mail/reset_password.erb
+++ b/app/views/account/mail/reset_password.erb
@@ -11,7 +11,7 @@
 <hr/>
 
 <p>
-This email is sent from <a href="<%= Environment.config['hostname'] %>">Scout</a>, a service of the <a href="http://sunlightfoundation.com">Sunlight Foundation</a>.
+This email is sent from <a href="<%= Environment.config['hostname'] %>">Scout</a>, a service of the <a href="<%= Environment.config['organization']['url'] %>"><%= Environment.config['organization']['name'] %></a>.
 </p>
 
 <p>

--- a/app/views/account/settings.erb
+++ b/app/views/account/settings.erb
@@ -141,9 +141,9 @@
               <span>Get updates about new Scout features</span>
             </label>
 
-            <label for="sunlight_announcements">
-              <%= check_box_tag "user[sunlight_announcements]", checked: user.sunlight_announcements?, uncheck_value: 'false', id: "sunlight_announcements" %>
-              <span>Get updates about the Sunlight Foundation</span>
+            <label for="organization_announcements">
+              <%= check_box_tag "user[organization_announcements]", checked: user.organization_announcements?, uncheck_value: 'false', id: "organization_announcements" %>
+              <span>Get updates about the <%= Environment.config['organization']['name'] %></span>
             </label>
           </fieldset>
 

--- a/app/views/account/unsubscribe.erb
+++ b/app/views/account/unsubscribe.erb
@@ -1,7 +1,7 @@
 <div class="settings login contentArea full">
   <div class="module notifications">
 
-    <% if (current_user.notifications == "none") and !current_user.announcements? and !current_user.sunlight_announcements? %>
+    <% if (current_user.notifications == "none") and !current_user.announcements? and !current_user.organization_announcements? %>
       <h3>You're Unsubscribed</h3>
       <p>
         You're unsubscribed from everything. If you think we haven't properly unsubscribed you, <a href="mailto:scout+contact@sunlightfoundation.com">send us an email</a> and we'll take care of it.
@@ -10,7 +10,7 @@
       <h3>Unsubscribe from Everything?</h3>
 
       <p>
-        This will turn off emails for new alerts, Scout feature announcements, and Sunlight Foundation announcements.
+        This will turn off emails for new alerts, Scout feature announcements, and <%= Environment.config['organization']['name'] %> announcements.
       </p>
 
       <form action="/account/unsubscribe/actually" method="post">

--- a/app/views/account/welcome.erb
+++ b/app/views/account/welcome.erb
@@ -33,9 +33,9 @@
               <span>Get updates about new Scout features</span>
             </label>
 
-            <label for="sunlight_announcements">
-              <%= check_box_tag "user[sunlight_announcements]", checked: user.sunlight_announcements?, uncheck_value: 'false', id: "sunlight_announcements" %>
-              <span>Get updates about the Sunlight Foundation</span>
+            <label for="organization_announcements">
+              <%= check_box_tag "user[organization_announcements]", checked: user.organization_announcements?, uncheck_value: 'false', id: "organization_announcements" %>
+              <span>Get updates about the <%= Environment.config['organization']['name'] %></span>
             </label>
           </fieldset>
         </ul>

--- a/config/config.yml.example
+++ b/config/config.yml.example
@@ -1,3 +1,8 @@
+# Change the following settings to match your organization's details.
+organization:
+  name: Sunlight Foundation
+  url: http://sunlightfoundation.com/
+
 subscriptions:
   # fill in with your own Sunlight API key
   sunlight_api_key:

--- a/test/functional/accounts_test.rb
+++ b/test/functional/accounts_test.rb
@@ -383,11 +383,11 @@ class AccountsTest < Test::Unit::TestCase
   #### Unsubscribe ####
 
   def test_unsubscribe_actual
-    user = create :user, sunlight_announcements: true, announcements: true
+    user = create :user, organization_announcements: true, announcements: true
 
     assert_equal 'email_immediate', user.notifications
     assert_equal true, user.announcements
-    assert_equal true, user.sunlight_announcements
+    assert_equal true, user.organization_announcements
 
     post '/account/unsubscribe/actually', {}, login(user)
     assert_redirect "/account/unsubscribe"
@@ -396,7 +396,7 @@ class AccountsTest < Test::Unit::TestCase
 
     assert_equal 'none', user.notifications
     assert_equal false, user.announcements
-    assert_equal false, user.sunlight_announcements
+    assert_equal false, user.organization_announcements
   end
 
   def test_unsubscribe_actual_not_logged_in
@@ -406,11 +406,11 @@ class AccountsTest < Test::Unit::TestCase
 
   # doesn't actually do the unsubscribe
   def test_unsubscribe_landing
-    user = create :user, sunlight_announcements: true, announcements: true
+    user = create :user, organization_announcements: true, announcements: true
 
     assert_equal 'email_immediate', user.notifications
     assert_equal true, user.announcements
-    assert_equal true, user.sunlight_announcements
+    assert_equal true, user.organization_announcements
 
     get '/account/unsubscribe', {}, login(user)
     assert_response 200
@@ -419,7 +419,7 @@ class AccountsTest < Test::Unit::TestCase
 
     assert_equal 'email_immediate', user.notifications
     assert_equal true, user.announcements
-    assert_equal true, user.sunlight_announcements
+    assert_equal true, user.organization_announcements
   end
 
   def test_unsubscribe_landing_not_logged_in

--- a/test/functional/login_test.rb
+++ b/test/functional/login_test.rb
@@ -147,7 +147,7 @@ class LoginTest < Test::Unit::TestCase
     assert_not_nil user
     assert User.authenticate(user, password)
     assert !user.announcements
-    assert !user.sunlight_announcements
+    assert !user.organization_announcements
     assert !user.confirmed?
     assert user.should_change_password?
     assert_equal "quick", user.signup_process
@@ -292,9 +292,9 @@ class LoginTest < Test::Unit::TestCase
     password = "testing"
     assert !User.authenticate(user, password)
     assert !user.announcements?
-    assert !user.sunlight_announcements?
+    assert !user.organization_announcements?
 
-    put "/account/welcome", {password: password, password_confirmation: password, user: {announcements: true, sunlight_announcements: true}}, login(user)
+    put "/account/welcome", {password: password, password_confirmation: password, user: {announcements: true, organization_announcements: true}}, login(user)
     assert_redirect "/account/settings"
 
     user.reload
@@ -302,7 +302,7 @@ class LoginTest < Test::Unit::TestCase
 
     assert User.authenticate(user, password)
     assert user.announcements?
-    assert user.sunlight_announcements?
+    assert user.organization_announcements?
   end
 
   def test_welcome_form_mismatched_passwords
@@ -311,9 +311,9 @@ class LoginTest < Test::Unit::TestCase
     password = "testing"
     assert !User.authenticate(user, password)
     assert !user.announcements?
-    assert !user.sunlight_announcements?
+    assert !user.organization_announcements?
 
-    put "/account/welcome", {password: password, password_confirmation: password.succ, user: {announcements: true, sunlight_announcements: true}}, login(user)
+    put "/account/welcome", {password: password, password_confirmation: password.succ, user: {announcements: true, organization_announcements: true}}, login(user)
     assert_response 200
 
     user.reload
@@ -321,7 +321,7 @@ class LoginTest < Test::Unit::TestCase
 
     assert !User.authenticate(user, password)
     assert !user.announcements?
-    assert !user.sunlight_announcements?
+    assert !user.organization_announcements?
   end
 
   def test_welcome_form_logged_out
@@ -330,9 +330,9 @@ class LoginTest < Test::Unit::TestCase
     password = "testing"
     assert !User.authenticate(user, password)
     assert !user.announcements?
-    assert !user.sunlight_announcements?
+    assert !user.organization_announcements?
 
-    put "/account/welcome", {password: password, password_confirmation: password.succ, user: {announcements: true, sunlight_announcements: true}}
+    put "/account/welcome", {password: password, password_confirmation: password.succ, user: {announcements: true, organization_announcements: true}}
     assert_redirect "/"
 
     user.reload
@@ -340,7 +340,7 @@ class LoginTest < Test::Unit::TestCase
 
     assert !User.authenticate(user, password)
     assert !user.announcements?
-    assert !user.sunlight_announcements?
+    assert !user.organization_announcements?
   end
 
 
@@ -350,14 +350,14 @@ class LoginTest < Test::Unit::TestCase
     email = "fake@example.com"
     assert_nil User.where(email: email).first
 
-    post '/account/new', {user: {'email' => email, 'password' => "test", 'password_confirmation' => "test", 'announcements' => false, 'sunlight_announcements' => true}}
+    post '/account/new', {user: {'email' => email, 'password' => "test", 'password_confirmation' => "test", 'announcements' => false, 'organization_announcements' => true}}
     assert_redirect '/account/settings'
 
     user = User.where(:email => email).first
     assert_not_nil user
     assert User.authenticate(user, "test")
     assert !user.announcements
-    assert user.sunlight_announcements
+    assert user.organization_announcements
     assert user.confirmed?
     assert_nil user.signup_process
   end
@@ -368,7 +368,7 @@ class LoginTest < Test::Unit::TestCase
 
     campaign = {'campaign' => {'utm_source' => 'source', 'utm_medium' => 'banner', 'utm_content' => '640', 'utm_campaign' => 'campaign'}}
 
-    post '/account/new', {:user => {'email' => email, 'password' => "test", 'password_confirmation' => "test", 'announcements' => false, 'sunlight_announcements' => true}}, session(campaign)
+    post '/account/new', {:user => {'email' => email, 'password' => "test", 'password_confirmation' => "test", 'announcements' => false, 'organization_announcements' => true}}, session(campaign)
     assert_redirect '/account/settings'
 
     user = User.where(:email => email).first

--- a/test/functional/remote_test.rb
+++ b/test/functional/remote_test.rb
@@ -53,7 +53,7 @@ class RemoteTest < Test::Unit::TestCase
     assert_not_nil user.password_hash
     assert !user.should_change_password?
     assert !user.announcements?
-    assert !user.sunlight_announcements?
+    assert !user.organization_announcements?
 
     assert_not_nil user.synced_at
 
@@ -444,7 +444,7 @@ class RemoteTest < Test::Unit::TestCase
     assert !user.phone_confirmed?
 
     assert !user.announcements
-    assert !user.sunlight_announcements
+    assert !user.organization_announcements
 
     assert_equal 1, user.interests.count
     interest = user.interests.first


### PR DESCRIPTION
- Alias `organization_announcements` to `sunlight_announcements` in Mongoid, i.e. the field name in MongoDB is still `sunlight_announcements` to avoid breaking existing databases, but the field name everywhere else in the code is now `organization_announcements`.
- Add `organization` section to `config.yml`, with `name` and `url` keys. To upgrade, simply add this section to your production `config.yml` file. I haven't used these new configuration variables everywhere - I've just updated the parts related to the announcements functionality.
