### PR TITLE
Make RSS description configurable

### DIFF
--- a/app/views/rss/collection.erb
+++ b/app/views/rss/collection.erb
@@ -3,9 +3,7 @@
   <channel>
     <title>Scout - Activity for collection "<%= collection.name %>"</title>
     <link><%= Environment.config['hostname'] %></link>
-    <description>
-      US government-wide search and notification service. Created by the Sunlight Foundation, a non-profit dedicated to using the power of technology to increase government transparency and accountability.
-    </description>
+    <description><%= Environment.config['rss']['description'] %></description>
     <language>en-us</language>
     <atom:link href="<%= url %>" rel="self" type="application/rss+xml" />
 

--- a/app/views/rss/interest.erb
+++ b/app/views/rss/interest.erb
@@ -3,9 +3,7 @@
   <channel>
     <title>Scout - Activity for <%= interest_name interest %></title>
     <link><%= Environment.config['hostname'] %></link>
-    <description>
-      US government-wide search and notification service. Created by the Sunlight Foundation, a non-profit dedicated to using the power of technology to increase government transparency and accountability.
-    </description>
+    <description><%= Environment.config['rss']['description'] %></description>
     <language>en-us</language>
     <atom:link href="<%= url %>" rel="self" type="application/rss+xml" />
     

--- a/config/config.yml.example
+++ b/config/config.yml.example
@@ -48,6 +48,10 @@ twilio:
   auth_token:
   from: # phone number
 
+# RSS configuration.
+rss:
+  description: US government-wide search and notification service. Created by the Sunlight Foundation, a non-profit dedicated to using the power of technology to increase government transparency and accountability.
+
 # outputs polled URLs to STDOUT
 debug:
   output_urls: true


### PR DESCRIPTION
To upgrade, just copy the default `rss` block from `config.yml.example` into your production `config.yml`.
