### PR TITLE
Make the domain in SMS messages configurable

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -239,7 +239,7 @@ class User
   end
 
   def self.phone_remote_confirm_message(password)
-    "Your number has been confirmed. Log in to scout.sunlightfoundation.com with the password \"#{password}\" to manage your alerts." # Text \"HELP\" for a list of commands."
+    "Your number has been confirmed. Log in to #{Environment.config['twilio']['domain']} with the password \"#{password}\" to manage your alerts." # Text \"HELP\" for a list of commands."
   end
 
   # turn off the user's email notifications, and any announcement subscriptions

--- a/config/config.yml.example
+++ b/config/config.yml.example
@@ -44,6 +44,8 @@ email:
 
 # SMS details
 twilio:
+  # The app's domain for display to users.
+  domain: scout.sunlightfoundation.com
   account_sid:
   auth_token:
   from: # phone number


### PR DESCRIPTION
To upgrade,  just add a `domain` key under the `twilio` key in your production `config.yml` file.
