### PR TITLE
Add quick-and-dirty way to control which subscription adapters are loaded

### DIFF
--- a/config/config.yml.example
+++ b/config/config.yml.example
@@ -64,6 +64,21 @@ admin:
 analytics:
   -
 
+# A list of filenames of subscription adapters to load (loads all if empty)
+adapters:
+  - feed # required
+  - documents
+  - federal_bills
+  - federal_bills_activity
+  - federal_bills_hearings
+  - federal_bills_upcoming_floor
+  - federal_bills_votes
+  - regulations
+  - speeches
+  - state_bills
+  - state_bills_activity
+  - state_bills_votes
+
 # Mongoid details
 mongoid:
   development:


### PR DESCRIPTION
It's now possible to turn off Sunlight's default adapters. `config.yml.example` includes enough adapters to get the tests to pass. There should not be any change needed in production.

Need to do something about this line in `scout.rb` for the development environment:

``` ruby
config.also_reload "./subscriptions/adapters/*.rb"
```

And need to do something about these lines in the `Rakefile` for cron jobs in production:

``` ruby
subscription_types = Dir.glob('subscriptions/adapters/*.rb').map do |file|
  File.basename file, File.extname(file)
end
```

Any ideas?
