### PR TITLE
Fix regular expression manipulation

### DIFF
--- a/subscriptions/helpers.rb
+++ b/subscriptions/helpers.rb
@@ -134,7 +134,7 @@ module Helpers
       patterns = keywords.map do |keyword|
         keyword = keyword.gsub '"', ''
         keyword = Regexp.escape(keyword)
-        keyword = keyword.gsub ' ', '[\s\-]'
+        keyword = keyword.gsub '\\ ', '[\s\-]'
 
         keyword
       end


### PR DESCRIPTION
It's because `Regexp.escape` escapes spaces, and we were inserting `[\s\-]` after the `\` before the space - escaping the opening `[` as a result
