### PR TITLE
Fix crash on /fetch/search/... route

### DIFF
--- a/app/views/search/items.erb
+++ b/app/views/search/items.erb
@@ -1,6 +1,6 @@
 <% if items %>
   <%# client-side pagination is just that %>
-  <% if defined?(per_page) %>
+  <% if defined?(per_page) && per_page %>
     <% items = items.first per_page %>
   <% end %>
 


### PR DESCRIPTION
Fix crash on /fetch/search/:subscription_type/:query/?:query_type? route when called without the per_page param. A nil per_page local variable must be supported by the items.erb template because the controller at search.rb:37 explicitly requests it. (Other controllers render this template but leave per_page undefined.)
