### PR TITLE
Refactor with Ruby's string formatting

### DIFF
--- a/app/helpers/general.rb
+++ b/app/helpers/general.rb
@@ -276,25 +276,6 @@ module Helpers
       local.strftime "%m/%d"
     end
 
-    def zero_prefix(number)
-      number.to_i < 10 ? "0#{number}" : number.to_s
-    end
-
-    def zero_prefix_five(number)
-      n = number.to_i
-      if n < 10
-        "0000#{number}"
-      elsif n < 100
-        "000#{number}"
-      elsif n < 1000
-        "00#{number}"
-      elsif n < 10000
-        "0#{number}"
-      else
-        number.to_s
-      end
-    end
-
     def light_format(string)
       return "" unless string.present?
       string = strip_tags string

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -210,7 +210,7 @@ class User
 
   # @private
   def self.short_token
-    zero_prefix rand(10000)
+    "%04d" % rand(10000)
   end
 
   def new_reset_token
@@ -260,20 +260,6 @@ class User
 
   def new_phone_verify_code
     self.phone_verify_code = User.short_token
-  end
-
-  # zero prefixes a number below 10,000 out to 4 digits
-  # @private
-  def self.zero_prefix(number)
-    if number < 10
-      "000#{number}"
-    elsif number < 100
-      "00#{number}"
-    elsif number < 1000
-      "0#{number}"
-    else
-      number.to_s
-    end
   end
 
   # XXX this method should be a helper method to the account controller, because it's View not Model code

--- a/subscriptions/helpers.rb
+++ b/subscriptions/helpers.rb
@@ -625,7 +625,7 @@ module Helpers
         "http://clerk.house.gov/evs/#{vote['year']}/roll#{vote['number']}.xml"
       elsif vote['chamber'] == "senate"
         subsession = {0 => 2, 1 => 1}[vote['year'].to_i % 2]
-        "http://www.senate.gov/legislative/LIS/roll_call_lists/roll_call_vote_cfm.cfm?congress=#{vote['session']}&session=#{subsession}&vote=#{zero_prefix_five vote['number']}"
+        "http://www.senate.gov/legislative/LIS/roll_call_lists/roll_call_vote_cfm.cfm?congress=#{vote['session']}&session=#{subsession}&vote=#{"%05d" % vote['number']}"
       end
     end
 


### PR DESCRIPTION
Refactor: Ruby's string formatting allows us to left-pad number strings with zeros to any given length. Use this and remove the zero_prefix and zero_prefix_five methods.
