### PR TITLE
Replace the control flow keywords "and" and "or" with boolean operators && and ||

### DIFF
--- a/app/controllers/account.rb
+++ b/app/controllers/account.rb
@@ -31,7 +31,7 @@ end
 put '/account/settings' do
   requires_login
 
-  if params[:user] and params[:user][:image]
+  if params[:user] && params[:user][:image]
     tempfile = params[:user][:image][:tempfile]
     params[:user].delete :image
     params[:user].delete 'image'
@@ -155,7 +155,7 @@ put '/account/phone' do
 
   current_user.phone = params[:user]['phone']
 
-  if Phoner::Phone.valid?(current_user.phone) and current_user.valid?
+  if Phoner::Phone.valid?(current_user.phone) && current_user.valid?
 
     # manually set to false, in case the phone number was set and is changing
     current_user.phone_confirmed = false

--- a/app/controllers/feeds.rb
+++ b/app/controllers/feeds.rb
@@ -25,7 +25,7 @@ helpers do
 
   def rss_for(view, items, locals = {})
     page = (params[:page] || 1).to_i
-    page = 1 if page <= 0 or page > 200000000
+    page = 1 if page <= 0 || page > 200000000
     per_page = 100
 
     items = items.skip(per_page * (page - 1)).limit(per_page)

--- a/app/controllers/import.rb
+++ b/app/controllers/import.rb
@@ -16,7 +16,7 @@ get "/import/feed/preview" do
         urls = Feedbag.find url
 
         # manually handle http->https error
-        if urls.empty? and !url.start_with?("https:")
+        if urls.empty? && !url.start_with?("https:")
           url = url.start_with?("http:") ? url : "http://#{url}"
           Feedbag.find url.sub(/^http:/, "https:")
         else

--- a/app/controllers/items.rb
+++ b/app/controllers/items.rb
@@ -94,7 +94,7 @@ post '/item/:item_type/:item_id/follow' do
   halt 200 and return unless interest.new_record?
 
   # todo: kill now that the map is fixed
-  adapter = if item_types[item_type] and item_types[item_type]['adapter']
+  adapter = if item_types[item_type] && item_types[item_type]['adapter']
     item_types[item_type]['adapter']
   else
     item_type.pluralize

--- a/app/controllers/login.rb
+++ b/app/controllers/login.rb
@@ -16,7 +16,7 @@ post '/login' do
 
   @new_user = User.new
 
-  if (user = User.where(email: login).first || User.by_phone(login)) and User.authenticate(user, params[:password])
+  if (user = User.where(email: login).first || User.by_phone(login)) && User.authenticate(user, params[:password])
     if user.service.present?
       Event.blocked_email! login, user.service
 

--- a/app/controllers/user.rb
+++ b/app/controllers/user.rb
@@ -32,7 +32,7 @@ get "/user/:user_id/:collection" do
 
   user, collection = load_user_and_collection
 
-  if collection.private? and (user != current_user)
+  if collection.private? && (user != current_user)
     halt 404 and return
   end
 

--- a/app/helpers/general.rb
+++ b/app/helpers/general.rb
@@ -27,7 +27,7 @@ module Helpers
     end
 
     def page_title(interest)
-      if (interest.query_type == "simple") and (interest.query['citations'] and interest.query['citations'].any?)
+      if (interest.query_type == "simple") && (interest.query['citations'] && interest.query['citations'].any?)
         name = Search.cite_standard interest.query['citations'].first
       else
         name = interest.in
@@ -116,7 +116,7 @@ module Helpers
 
     def errors_for(object)
 
-      if object and object.errors and object.errors.any?
+      if object && object.errors && object.errors.any?
         object.errors.map do |key, msg|
           "<div class=\"error user\">#{msg}</div>"
         end.join

--- a/app/helpers/routing.rb
+++ b/app/helpers/routing.rb
@@ -170,18 +170,18 @@ module Helpers
         item.data['url']
 
       # special case: Open States users get direct links
-      elsif interest and user and (user.service == "open_states")
-        if interest.search? and interest.search_type == "state_bills"
+      elsif interest && user && (user.service == "open_states")
+        if interest.search? && interest.search_type == "state_bills"
           openstates_url item.data
-        elsif interest.item? and interest.item_type == "state_bill"
+        elsif interest.item? && interest.item_type == "state_bill"
           openstates_url interest.data
-        elsif interest.item? and interest.item_type == "state_legislator"
+        elsif interest.item? && interest.item_type == "state_legislator"
           openstates_url item.data
         end
 
       # item subscription adapters must each define a direct_item_url method
-      elsif item.item? and interest and
-        (adapter = Subscription.adapter_for(item.subscription_type)) and
+      elsif item.item? && interest &&
+        (adapter = Subscription.adapter_for(item.subscription_type)) &&
         (url = adapter.direct_item_url item.data, interest)
         url
       else
@@ -227,7 +227,7 @@ module Helpers
         end
       end
 
-      if user and user.service.present?
+      if user && user.service.present?
         data[:d][:service] = user.service
       end
 

--- a/app/models/interest.rb
+++ b/app/models/interest.rb
@@ -408,7 +408,7 @@ class Interest
   def self.subscription_for(interest, subscription_type, regenerate = false)
     # if the interest is created, and we're not asking for regeneration,
     # we can count on the interest having it
-    if !interest.new_record? and !regenerate
+    if !interest.new_record? && !regenerate
       return interest.subscriptions.where(subscription_type: subscription_type).first
     end
 

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -179,13 +179,13 @@ module Search
     distance = []
 
     parsed.each do |piece|
-      if term = (piece[:term] or piece[:word] or piece[:phrase])
+      if term = (piece[:term] || piece[:word] || piece[:phrase])
         term = term.to_s
         
         if piece[:prohibited]
           excluded << {'term' => term}
 
-        elsif piece[:distance] and piece[:distance].to_s.to_i > 0
+        elsif piece[:distance] && piece[:distance].to_s.to_i > 0
           # split term into words
           # (doesn't support distance between multi-word phrases)
           # (doesn't support citations)
@@ -244,7 +244,7 @@ module Search
   def self.normalize(query)
     string = ""
 
-    if query['citations'] and query['citations'].any?
+    if query['citations'] && query['citations'].any?
       # start with sorted citations, if any
       string << query['citations'].map do |cite|
         "#{cite['citation_type']}:#{cite['citation_id']}"

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -127,7 +127,7 @@ class User
     types = []
     types << "email_daily" if email.present?
     types << "email_immediate" if email.present?
-    types << "sms" if phone.present? and phone_confirmed
+    types << "sms" if phone.present? && phone_confirmed
     types << "none"
     types
   end

--- a/config/email.rb
+++ b/config/email.rb
@@ -30,7 +30,7 @@ module Email
     puts "EXCEPTION SENDING EMAIL:"
     puts "\n#{exc.class}"
     puts "\n#{exc.message}"
-    if exc.backtrace and exc.backtrace.respond_to?(:each)
+    if exc.backtrace && exc.backtrace.respond_to?(:each)
       exc.backtrace.each do |line|
         puts line
       end
@@ -108,7 +108,7 @@ module Email
       true
     rescue Exception => e
       # if it's a hard bounce to a valid user, unsubscribe that user from future emails
-      if e.is_a?(Postmark::InvalidMessageError) and e.message["hard bounce or a spam complaint"]
+      if e.is_a?(Postmark::InvalidMessageError) && e.message["hard bounce or a spam complaint"]
         if user = User.where(email: to).first
           user.unsubscribe!
           Admin.report(

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -32,7 +32,7 @@ class Environment
   end
 
   def self.asset_path(path)
-    if config['assets'] and config['assets']['enabled']
+    if config['assets'] && config['assets']['enabled']
       File.join Environment.config['assets']['asset_host'], "assets", path
     else
       File.join "/assets", path

--- a/deliveries/email.rb
+++ b/deliveries/email.rb
@@ -235,7 +235,7 @@ module Deliveries
         subject << grouped.map do |subscription_type, subscription_deliveries|
           type = "#{subscription_deliveries.size} #{Subscription.adapter_for(subscription_type).short_name subscription_deliveries.size, interest}"
 
-          if grouped.keys.size == 1 and interest.filters.any?
+          if grouped.keys.size == 1 && interest.filters.any?
             filters = interest.filters.map do |field, value|
               interest.filter_name field, value
             end.join(", ")

--- a/deliveries/manager.rb
+++ b/deliveries/manager.rb
@@ -145,7 +145,7 @@ module Deliveries
         puts "#{header} Not scheduling delivery, user wants no notifications for this interest" unless Sinatra::Application.test?
       elsif !user.confirmed?
         puts "#{header} Not scheduling delivery, user is unconfirmed" unless Sinatra::Application.test?
-      elsif (mechanism == "sms") and (user.phone.blank? or !user.phone_confirmed)
+      elsif (mechanism == "sms") && (user.phone.blank? || !user.phone_confirmed)
         puts "#{header} Not scheduling delivery, it is for SMS and user has no confirmed phone number" unless Sinatra::Application.test?
       else
         puts "#{header} Scheduling delivery" unless Sinatra::Application.test?

--- a/subscriptions/adapters/court_opinions.rb
+++ b/subscriptions/adapters/court_opinions.rb
@@ -76,7 +76,7 @@ module Subscriptions
           query = subscription.interest_in
           return nil unless query.present?
           url << "&q=#{CGI.escape query}"
-        elsif query.present? and !["*", "\"*\""].include?(query)
+        elsif query.present? && !["*", "\"*\""].include?(query)
           url << "&q=#{CGI.escape query}"
         end
 
@@ -202,7 +202,7 @@ module Subscriptions
           opinion['download_url'] = opinion['download_URL']
         end
 
-        if opinion['citation'] and opinion['citation']['case_name']
+        if opinion['citation'] && opinion['citation']['case_name']
           opinion['case_name'] = opinion['citation']['case_name']
         end
 

--- a/subscriptions/adapters/documents.rb
+++ b/subscriptions/adapters/documents.rb
@@ -38,7 +38,7 @@ module Subscriptions
         url << "/documents/search?"
 
         query = subscription.query['query']
-        if query.present? and !["*", "\"*\""].include?(query)
+        if query.present? && !["*", "\"*\""].include?(query)
           url << "&query=#{CGI.escape query}"
 
           url << "&highlight=true"

--- a/subscriptions/adapters/federal_bills.rb
+++ b/subscriptions/adapters/federal_bills.rb
@@ -46,7 +46,7 @@ module Subscriptions
           url << "&bill_type=#{federal_bill[0]}"
           url << "&number=#{federal_bill[1]}"
 
-        elsif query.present? and !["*", "\"*\""].include?(query)
+        elsif query.present? && !["*", "\"*\""].include?(query)
           url << "&query=#{CGI.escape query}"
 
           url << "&highlight=true"
@@ -162,7 +162,7 @@ module Subscriptions
       # given a seen item (bill), return the document URL to fetch
       def self.document_url(item)
         bill = item.data
-        if bill['last_version'] and bill['last_version']['urls']['xml']
+        if bill['last_version'] && bill['last_version']['urls']['xml']
           bill_version_id = bill['last_version']['bill_version_id']
           "http://unitedstates.sunlightfoundation.com/documents/bills/#{bill['congress']}/#{bill['bill_type']}/#{bill_version_id}.htm"
         end
@@ -250,7 +250,7 @@ module Subscriptions
         if now.month == 1
           if [1, 2].include?(now.day)
             year - 1
-          elsif (now.day == 3) and (now.hour < 12)
+          elsif (now.day == 3) && (now.hour < 12)
             year - 1
           else
             year

--- a/subscriptions/adapters/federal_bills_activity.rb
+++ b/subscriptions/adapters/federal_bills_activity.rb
@@ -50,7 +50,7 @@ module Subscriptions
         response['results'].first['actions'].each do |action|
           # don't alert on vote actions, they are handled separately, by the votes adapter
           # but do show them on the front-end, weird to pretend it's not there
-          next if (action['type'] == "vote") and (function != :search)
+          next if (action['type'] == "vote") && (function != :search)
 
           actions << item_for(bill_id, action)
         end

--- a/subscriptions/adapters/feed.rb
+++ b/subscriptions/adapters/feed.rb
@@ -145,7 +145,7 @@ module Subscriptions
         inner = inner.at("p") if inner.at("p")
 
         last_link = (inner / :a).last
-        if last_link and last_link.inner_text.blank?
+        if last_link && last_link.inner_text.blank?
           last_link.remove
           inner.inner_html + "…"
         else

--- a/subscriptions/adapters/regulations.rb
+++ b/subscriptions/adapters/regulations.rb
@@ -47,7 +47,7 @@ module Subscriptions
         url << "/regulations/search?"
 
         query = subscription.query['query']
-        if query.present? and !["*", "\"*\""].include?(query)
+        if query.present? && !["*", "\"*\""].include?(query)
           url << "&query=#{CGI.escape query}"
 
           url << "&highlight=true"

--- a/subscriptions/adapters/speeches.rb
+++ b/subscriptions/adapters/speeches.rb
@@ -42,7 +42,7 @@ module Subscriptions
 
         url = "#{endpoint}/text.json?apikey=#{api_key}"
 
-        if query.present? and !["\"*\"", "*"].include?(query)
+        if query.present? && !["\"*\"", "*"].include?(query)
           url << "&q=#{CGI.escape query}"
         end
 

--- a/subscriptions/adapters/state_bills.rb
+++ b/subscriptions/adapters/state_bills.rb
@@ -85,7 +85,7 @@ module Subscriptions
           # if there's a state bill code, extract it and apply the specific bill_ids__in filter
           if state_bill = Search.state_bill_for(query)
             url << "&bill_id__in=#{CGI.escape state_bill}"
-          elsif query.present? and !["*", "\"*\""].include?(query)
+          elsif query.present? && !["*", "\"*\""].include?(query)
             url << "&q=#{CGI.escape query}"
           end
         end
@@ -115,7 +115,7 @@ module Subscriptions
         end
 
         # subjects - array of strings, e.g. ["Agriculture and Food", "Public Services"]
-        if subscription.data['subjects'].present? and subscription.data['subjects'].any?
+        if subscription.data['subjects'].present? && subscription.data['subjects'].any?
           url << subscription.data['subjects'].map {|s| "&subjects=#{s}"}.join("")
         end
 
@@ -247,7 +247,7 @@ module Subscriptions
         end
 
         # use most recent action for the date, if present (which it should always be)
-        if bill['action_dates'] and bill['action_dates']['last']
+        if bill['action_dates'] && bill['action_dates']['last']
           date = bill['action_dates']['last']
         else
           date = bill['created_at']

--- a/subscriptions/adapters/state_legislators_bills.rb
+++ b/subscriptions/adapters/state_legislators_bills.rb
@@ -95,7 +95,7 @@ module Subscriptions
 
         # use first action (introduction date) for a sponsored bills feed
         # first action should always be present, but just in case, default to created date
-        if bill['action_dates'] and bill['action_dates']['first']
+        if bill['action_dates'] && bill['action_dates']['first']
           date = bill['action_dates']['first']
         else
           date = bill['created_at']

--- a/subscriptions/helpers.rb
+++ b/subscriptions/helpers.rb
@@ -80,11 +80,11 @@ module Helpers
     def bill_highlight(item, interest, options = {})
       keywords = keywords_from interest
 
-      if item.data['citations'] and item.data['citations'].any?
+      if item.data['citations'] && item.data['citations'].any?
         matches = item.data['citations'].map {|c| c['match']}
         cite = item.data['citations'].first
         excerpt cite['excerpt'], (keywords + matches), options
-      elsif item.data['search'] and item.data['search']['highlight']
+      elsif item.data['search'] && item.data['search']['highlight']
         field = preferred_field item, bill_priorities
         return nil unless field
 
@@ -102,11 +102,11 @@ module Helpers
     def regulation_highlight(item, interest, options = {})
       keywords = keywords_from interest
 
-      if item.data['citations'] and item.data['citations'].any?
+      if item.data['citations'] && item.data['citations'].any?
         matches = item.data['citations'].map {|c| c['match']}
         cite = item.data['citations'].first
         excerpt cite['excerpt'], (keywords + matches), options
-      elsif item.data['search'] and item.data['search']['highlight']
+      elsif item.data['search'] && item.data['search']['highlight']
         field = preferred_field item, regulation_priorities
         return nil unless field
         text = item.data['search']['highlight'][field].first
@@ -119,11 +119,11 @@ module Helpers
     def document_highlight(item, interest, options = {})
       keywords = keywords_from interest
 
-      if item.data['citations'] and item.data['citations'].any?
+      if item.data['citations'] && item.data['citations'].any?
         matches = item.data['citations'].map {|c| c['match']}
         cite = item.data['citations'].first
         excerpt cite['excerpt'], (keywords + matches), options
-      elsif item.data['search'] and item.data['search']['highlight']
+      elsif item.data['search'] && item.data['search']['highlight']
         field = preferred_field item, document_priorities
         return nil unless field
         text = item.data['search']['highlight'][field].first
@@ -394,7 +394,7 @@ module Helpers
 
     # XXX only used by federal_bills views
     def bill_text_url(bill, version)
-      if version and version['urls']
+      if version && version['urls']
         version['urls']['xml'] || version['urls']['pdf']
       end
     end
@@ -561,7 +561,7 @@ module Helpers
 
     # XXX only used by regulations views
     def regulation_type(regulation)
-      if regulation['article_type'].nil? or (regulation['article_type'] == "regulation")
+      if regulation['article_type'].nil? || (regulation['article_type'] == "regulation")
         {
           "proposed" => "Proposed Rule",
           "final" => "Final Rule"
@@ -591,7 +591,7 @@ module Helpers
     # XXX only used by state_bills_votes views
     def state_vote_type(vote)
       type = ""
-      if vote['committee'] or vote['motion'] =~ /committee/i
+      if vote['committee'] || vote['motion'] =~ /committee/i
         type = "Committee "
       end
       "#{type}#{vote['type'].capitalize}"

--- a/subscriptions/manager.rb
+++ b/subscriptions/manager.rb
@@ -58,7 +58,7 @@ module Subscriptions
       subscription_type = subscription.subscription_type
 
       # if the subscription is orphaned, catch this, warn admin, and abort
-      if interest.nil? and !dry_run
+      if interest.nil? && !dry_run
         subscription.seen_items.each {|i| i.destroy}
         subscription.destroy
         Admin.report Report.warning("Check", "Orphaned subscription, deleting, moving on", subscription: subscription.attributes.dup)
@@ -109,10 +109,10 @@ module Subscriptions
 
           mark_as_seen! item unless dry_run
 
-          if (subscription.subscription_type == "court_opinions") and !Subscriptions::Adapters::CourtOpinions.double_check(item)
+          if (subscription.subscription_type == "court_opinions") && !Subscriptions::Adapters::CourtOpinions.double_check(item)
             courtlistener_warnings << item.attributes
 
-          elsif !test? and (item.date < backfill_date)
+          elsif !test? && (item.date < backfill_date)
             backfills << item.attributes
 
           else
@@ -183,7 +183,7 @@ module Subscriptions
       adapter = subscription.adapter
       url = adapter.url_for subscription, function, options
 
-      puts "\n[#{subscription.subscription_type}][#{function}][#{subscription.interest_in}][#{subscription.id}] #{url}\n\n" if !test? and Environment.config['debug']['output_urls']
+      puts "\n[#{subscription.subscription_type}][#{function}][#{subscription.interest_in}][#{subscription.id}] #{url}\n\n" if !test? && Environment.config['debug']['output_urls']
 
       # Feed parser
       if adapter.respond_to?(:url_to_response)
@@ -209,7 +209,7 @@ module Subscriptions
       else
         items = begin
           # searches use a caching layer
-          if (function == :search) and (body = cache_for(url, :search, subscription.subscription_type))
+          if (function == :search) && (body = cache_for(url, :search, subscription.subscription_type))
             # should be guaranteed to work
             response = ::Oj.load body, mode: :compat
 
@@ -223,7 +223,7 @@ module Subscriptions
             response = ::Oj.load body, mode: :compat
 
             # wait for JSON parse, so as not to cache errors
-            if (function == :search) and !Environment.config['no_cache']
+            if (function == :search) && !Environment.config['no_cache']
               cache! url, :search, subscription.subscription_type, body
             end
           end
@@ -288,7 +288,7 @@ module Subscriptions
 
       url = adapter.url_for_detail item_id, options
 
-      puts "\n[#{adapter_type}][find][#{item_id}] #{url}\n\n" if !test? and Environment.config['debug']['output_urls']
+      puts "\n[#{adapter_type}][find][#{item_id}] #{url}\n\n" if !test? && Environment.config['debug']['output_urls']
 
       # top-layer cache - if we've synced the item already, use it
       if item = item_cache_for(item_type, item_id)
@@ -325,7 +325,7 @@ module Subscriptions
         item.item_type = item_type
         item.find_url = url
 
-        if adapter.respond_to?(:document_url) and (url = adapter.document_url item)
+        if adapter.respond_to?(:document_url) && (url = adapter.document_url item)
           # a url_type of 'document' means their cache will not get flushed --
           # which is what we want. keep documents forever.
           item.data['document'] = fetch url, :document, options
@@ -346,7 +346,7 @@ module Subscriptions
     # @return [String] the response body
     # @private
     def self.fetch(url, url_type, options = {})
-      puts "\n[fetch][#{url_type}] #{url}\n\n" if !test? and Environment.config['debug']['output_urls']
+      puts "\n[fetch][#{url_type}] #{url}\n\n" if !test? && Environment.config['debug']['output_urls']
 
       body = nil
       begin
@@ -389,7 +389,7 @@ module Subscriptions
       adapter = Subscription.adapter_for subscription_type
       url = adapter.url_for_sync options
 
-      puts "\n[#{subscription_type}][sync][#{options[:page]}] #{url}\n\n" if !test? and Environment.config['debug']['output_urls']
+      puts "\n[#{subscription_type}][sync][#{options[:page]}] #{url}\n\n" if !test? && Environment.config['debug']['output_urls']
 
       items = begin
         body = download url, adapter
@@ -414,7 +414,7 @@ module Subscriptions
       items.map do |item|
         item.item_type = search_adapters[subscription_type]
 
-        if adapter.respond_to?(:document_url) and (url = adapter.document_url item)
+        if adapter.respond_to?(:document_url) && (url = adapter.document_url item)
           # a url_type of 'document' means their cache will not get flushed --
           # which is what we want. keep documents forever.
           item.data['document'] = fetch url, :document, options
@@ -469,7 +469,7 @@ module Subscriptions
       curl.headers["User-Agent"] = "Scout (scout.sunlightfoundation.com) / curl"
 
       # provide adapter an optional chance to modify Curl request
-      if adapter and adapter.respond_to?(:http)
+      if adapter && adapter.respond_to?(:http)
         curl = adapter.http curl
       end
 


### PR DESCRIPTION
Replace the control flow keywords "and" and "or" with the boolean operators && and ||. It's just a safer practice. For instance, GitHub's Ruby style guide (https://github.com/styleguide/ruby) says "The and and or keywords are banned. It's just not worth it. Always use && and || instead." Read http://devblog.avdi.org/2010/08/02/using-and-and-or-in-ruby/ for more rationale.

For your consideration :).
