### PR TITLE
Mention the blog post on IG reports in the source text

### DIFF
--- a/subscriptions/views/documents/_data.erb
+++ b/subscriptions/views/documents/_data.erb
@@ -2,7 +2,7 @@
   All GAO reports are sourced directly from the <a href="http://gao.gov">Government Accountability Office</a>.
 </p>
 <p>
-  All Inspector General reports are sourced directly from their original official website, and gathered using the <a href="https://github.com/unitedstates/inspectors-general#inspectors-general">unitedstates/inspectors-general</a> project.
+  All Inspector General reports are sourced directly from their original official website, and gathered using the <a href="https://github.com/unitedstates/inspectors-general#inspectors-general">unitedstates/inspectors-general</a> project. <a href="http://sunlightfoundation.com/blog/2014/05/13/why-weve-collected-a-hojillion-inspector-general-reports/">Read more about the project.</a>
 </p>
 <p>
   Scout's data covers 2009 to the present.


### PR DESCRIPTION
This adds a link to the IG report blog post I wrote to the Scout about text for IG reports.
