### PR TITLE
Moves anonymization flag before pageview

### DIFF
--- a/app/views/layout.erb
+++ b/app/views/layout.erb
@@ -226,10 +226,10 @@
       ga('global.send', 'pageview');
     <% end %>
 
-    ga('send', 'pageview');
-
     // IP anonymization (last triplet) - this is optional, not part of the standard snippet
     ga('set', 'anonymizeIp', true);
+
+    ga('send', 'pageview');
 
   </script>
 <% end %>


### PR DESCRIPTION
(My apologies for https://github.com/sunlightlabs/scout/commit/9e99e1a358e455de1df259bb2d5c409697c012fb, which I reverted in https://github.com/sunlightlabs/scout/commit/59da8f3f99602bfa4d46c5f10393f10ddf587c17 - I was editing in-browser and forgot I still had write permissions, I was thinking it would auto-fork.)

This moves the Google Analytics anonymize IP request up before the pageview is sent. The [Google Analytics IP anonymization docs](https://support.google.com/analytics/answer/2763052?hl=en) say: 

>  If the anonymization function has been called prior to the page tracking function, an additional parameter is added to the pixel request. The IP anonymization parameter looks like this: &aip=1

So that implies that this is the necessary order to me.
